### PR TITLE
Wrong wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ UTC Time as a Service
 
 ## How can I use this?
 
-For example, getting the current day of the month, use:
+For example, getting the current year, use:
 
 ### PHP
     <?php


### PR DESCRIPTION
Updated the readme to say year instead of day of the month as the example shows the year.
